### PR TITLE
Fix pointer alignment error

### DIFF
--- a/sgx_urts/src/ocall/sgxfile.rs
+++ b/sgx_urts/src/ocall/sgxfile.rs
@@ -53,14 +53,14 @@ pub unsafe extern "C" fn u_sgxfs_open_ocall(
             return ptr::null_mut();
         }
     };
-    *size = match file.size() {
+    let s = match file.size() {
         Ok(size) => size,
         Err(errno) => {
             set_error(error, errno);
             return ptr::null_mut();
         }
     };
-
+    size.write_unaligned(s);
     file.into_raw_stream() as *mut c_void
 }
 


### PR DESCRIPTION
ST:
```
thread 'main' panicked at /home/kai/.cargo/git/checkouts/incubator-teaclave-sgx-sdk-e1a16a9ae7d3e68c/cf82364/sgx_urts/src/ocall/sgxfile.rs:56:5:
misaligned pointer dereference: address must be a multiple of 0x8 but is 0x7ffcddd9208f
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a57770440f1ebe5b992551d3bcc489ae211908d4/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_nounwind_fmt
             at /rustc/a57770440f1ebe5b992551d3bcc489ae211908d4/library/core/src/panicking.rs:106:14
   2: core::panicking::panic_misaligned_pointer_dereference
             at /rustc/a57770440f1ebe5b992551d3bcc489ae211908d4/library/core/src/panicking.rs:202:5
   3: u_sgxfs_open_ocall
             at /home/kai/.cargo/git/checkouts/incubator-teaclave-sgx-sdk-e1a16a9ae7d3e68c/cf82364/sgx_urts/src/ocall/sgxfile.rs:56:5
   4: Enclave_u_sgxfs_open_ocall
             at /home/kai/litentry-parachain/tee-worker/service/Enclave_u.c:2197:18
   5: _ZN8CEnclave5ocallEjPK14_ocall_table_tPv
   6: <unknown>
   7: __morestack
   8: _Z8do_ecalliPKvS0_P12CTrustThread.part.0
   9: _ZN8CEnclave5ecallEiPKvPvb
  10: _ZL10_sgx_ecallmiPKvPvb
```

Reference: https://gitlab.com/dexlabs/incubator-teaclave-sgx-sdk/-/blob/a4a0bc5b9b32c192b4ee0c463a3c167cfe445a2b/samplecode/httpreq/enclave/src/lib.rs